### PR TITLE
"Cannot read property "node" from null"

### DIFF
--- a/customise-site-logo-repo/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/repository/site/site-logo.get.js
+++ b/customise-site-logo-repo/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/repository/site/site-logo.get.js
@@ -3,11 +3,15 @@ function main()
     // Get the filter parameters
     var site = args["site"];
     var siteObj = siteService.getSite(site);
+     if (siteObj == null) {
+          logger.log("Site não encontrado: " + site)
+        }else{
 	var siteNode = siteObj.node;
 
 	var site_logo = siteNode.childByNamePath("site_logo");
 
 	model.logo = site_logo ? site_logo.nodeRef.toString() : "";
+	}
 }
 
 main();

--- a/customise-site-logo-repo/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/repository/site/site-logo.get.js
+++ b/customise-site-logo-repo/src/main/resources/alfresco/extension/templates/webscripts/org/alfresco/repository/site/site-logo.get.js
@@ -4,7 +4,7 @@ function main()
     var site = args["site"];
     var siteObj = siteService.getSite(site);
      if (siteObj == null) {
-          logger.log("Site não encontrado: " + site)
+          logger.log("Site not found: " + site)
         }else{
 	var siteNode = siteObj.node;
 


### PR DESCRIPTION
In version 7.4 of alfresco, the user was getting this error every time he reloaded the page and was away from a site. I've added a basic check so that the end user doesn't run into it

![error-Alfresco](https://github.com/dgcloud/alfresco-share-site-logo-customization/assets/103136917/d879d769-154e-4b84-9c9e-9d50656a534a)
